### PR TITLE
[FEAT] 숙소 리스트 조회 api

### DIFF
--- a/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
+++ b/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login/**", "/test/**").permitAll()
+                        .requestMatchers("/login/**", "/stays/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtEntryPoint))
@@ -48,7 +48,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login/**", "/oauth2/**", "/test/**").permitAll()
+                        .requestMatchers("/", "/login/**", "/oauth2/**", "/stays/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/efub/agoda_server/global/exception/ErrorCode.java
+++ b/src/main/java/efub/agoda_server/global/exception/ErrorCode.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     // 타입(상태 코드, "메시지");
-
     // Default
-    ERROR(400, "요청 처리에 실패했습니다.");
+    ERROR(400, "요청 처리에 실패했습니다."),
+
+    //stay 관련 에러
+    PAST_CHECKIN_DATE(400, "체크인 날짜는 오늘 이후여야 합니다."),
+    INVALID_CHECKOUT_DATE(400, "체크아웃 날짜는 체크인 날짜보다 이후여야 합니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/efub/agoda_server/stay/controller/StayController.java
+++ b/src/main/java/efub/agoda_server/stay/controller/StayController.java
@@ -1,0 +1,30 @@
+package efub.agoda_server.stay.controller;
+
+import efub.agoda_server.stay.dto.response.StayListResponse;
+import efub.agoda_server.stay.service.StayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/stays")
+@RequiredArgsConstructor
+public class StayController {
+    private final StayService stayService;
+
+    @GetMapping
+    public ResponseEntity<StayListResponse> getStays(@RequestParam("city") String city,
+                                                     @RequestParam(value = "minPrice", defaultValue = "0") int minPrice,
+                                                     @RequestParam(value = "maxPrice", defaultValue = "2147483647") int maxPrice,
+                                                     @RequestParam("checkIn") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkIn,
+                                                     @RequestParam("checkOut") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkOut,
+                                                     @RequestParam(value = "page", defaultValue = "0") int page){
+        return ResponseEntity.ok(stayService.getStays(city, minPrice, maxPrice, checkIn, checkOut, page));
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/controller/StayController.java
+++ b/src/main/java/efub/agoda_server/stay/controller/StayController.java
@@ -5,10 +5,7 @@ import efub.agoda_server.stay.service.StayService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
@@ -19,12 +16,12 @@ public class StayController {
     private final StayService stayService;
 
     @GetMapping
-    public ResponseEntity<StayListResponse> getStays(@RequestParam("city") String city,
+    public ResponseEntity<StayListResponse> getAllStays(@RequestParam("city") String city,
                                                      @RequestParam(value = "minPrice", defaultValue = "0") int minPrice,
                                                      @RequestParam(value = "maxPrice", defaultValue = "2147483647") int maxPrice,
                                                      @RequestParam("checkIn") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkIn,
                                                      @RequestParam("checkOut") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkOut,
                                                      @RequestParam(value = "page", defaultValue = "0") int page){
-        return ResponseEntity.ok(stayService.getStays(city, minPrice, maxPrice, checkIn, checkOut, page));
+        return ResponseEntity.ok(stayService.getAllStays(city, minPrice, maxPrice, checkIn, checkOut, page));
     }
 }

--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -20,6 +20,9 @@ public class Stay {
     private long stId;
 
     @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
     private String city;
 
     @Column(nullable = false)

--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -3,6 +3,7 @@ package efub.agoda_server.stay.domain;
 import efub.agoda_server.converter.TagsConverter;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.List;
 
@@ -30,13 +31,29 @@ public class Stay {
     @Column(nullable = false, name = "sale_price")
     private int salePrice;
 
-    @Column(nullable = false)
-    private double rating;
-
     @Column(columnDefinition = "TEXT")
     @Convert(converter = TagsConverter.class)
     private List<String> tags;
 
     @Column(nullable = false)
     private String detail;
+
+    // 전체 평균 별점
+    @Column(name = "rating")
+    private double rating;
+
+    // 항목별 평균 별점
+    @Column(name = "addr_rating")
+    private double addrRating;
+
+    @Column(name = "sani_rating")
+    private double saniRating;
+
+    @Column(name = "serv_rating")
+    private double servRating;
+
+    // 총 리뷰 수
+    @Column(nullable = false, name = "review_cnt")
+    @ColumnDefault("0")
+    private int reviewCnt;
 }

--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -23,9 +23,6 @@ public class Stay {
     private String name;
 
     @Column(nullable = false)
-    private String city;
-
-    @Column(nullable = false)
     private String address;
 
     @Column(nullable = false)

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StayListResponse {
-    private String region;
+    private String search;
     private LocalDate checkIn;
     private LocalDate checkOut;
     private List<StaySummary> stays;
@@ -33,7 +33,7 @@ public class StayListResponse {
                 .collect(Collectors.toList());
 
         return StayListResponse.builder()
-                .region(city)
+                .search(city)
                 .checkIn(checkIn)
                 .checkOut(checkOut)
                 .stays(staySummarys)

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
@@ -1,0 +1,42 @@
+package efub.agoda_server.stay.dto.response;
+
+import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.dto.summary.StaySummary;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.domain.Page;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StayListResponse {
+    private String region;
+    private LocalDate checkIn;
+    private LocalDate checkOut;
+    private List<StaySummary> stays;
+
+    public static StayListResponse from(String city, LocalDate checkIn, LocalDate checkOut, Page<Stay> stays) {
+        //총 숙박일
+        int totalDays = (int) ChronoUnit.DAYS.between(checkIn, checkOut);
+
+        List<StaySummary> staySummarys = stays.getContent().stream()
+                .map(stay -> StaySummary.from(stay, totalDays))
+                .collect(Collectors.toList());
+
+        return StayListResponse.builder()
+                .region(city)
+                .checkIn(checkIn)
+                .checkOut(checkOut)
+                .stays(staySummarys)
+                .build();
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
@@ -1,0 +1,41 @@
+package efub.agoda_server.stay.dto.summary;
+
+import efub.agoda_server.stay.domain.Stay;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StaySummary {
+    private Long id;
+    private String name;
+    private String address;
+    private Double rating;
+    private int reviewCnt;
+    private int price;
+    private int salePrice;
+    private int totalPrice;
+    private List<String> tags;
+    private List<String> stayImgUrls;
+
+    //TODO: 이미지 경로 변경
+    public static StaySummary from(Stay stay, int totalDays){
+        return StaySummary.builder()
+                .id(stay.getStId())
+                .name(stay.getName())
+                .address(stay.getAddress())
+                .rating(stay.getRating())
+                .reviewCnt(stay.getReviewCnt())
+                .price(stay.getPrice())
+                .salePrice(stay.getSalePrice())
+                .totalPrice(stay.getSalePrice() * totalDays)
+                .tags(stay.getTags())
+                .stayImgUrls(List.of())
+                .build();
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/repository/StayRepository.java
+++ b/src/main/java/efub/agoda_server/stay/repository/StayRepository.java
@@ -1,0 +1,11 @@
+package efub.agoda_server.stay.repository;
+
+
+import efub.agoda_server.stay.domain.Stay;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StayRepository extends JpaRepository<Stay, Long> {
+    Page<Stay> findBySalePriceBetweenAndCity(int minPrice, int maxPrice, String city, Pageable pageable);
+}

--- a/src/main/java/efub/agoda_server/stay/repository/StayRepository.java
+++ b/src/main/java/efub/agoda_server/stay/repository/StayRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StayRepository extends JpaRepository<Stay, Long> {
-    Page<Stay> findBySalePriceBetweenAndCity(int minPrice, int maxPrice, String city, Pageable pageable);
+    Page<Stay> findBySalePriceBetweenAndAddressContaining(int minPrice, int maxPrice, String city, Pageable pageable);
 }

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -23,7 +23,7 @@ public class StayService {
     private final StayRepository stayRepository;
 
     @Transactional(readOnly = true)
-    public StayListResponse getStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
+    public StayListResponse getAllStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
         if(checkIn.isBefore(LocalDate.now()))
             throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
         if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -1,5 +1,7 @@
 package efub.agoda_server.stay.service;
 
+import efub.agoda_server.global.exception.CustomException;
+import efub.agoda_server.global.exception.ErrorCode;
 import efub.agoda_server.stay.domain.Stay;
 import efub.agoda_server.stay.dto.response.StayListResponse;
 import efub.agoda_server.stay.repository.StayRepository;
@@ -22,7 +24,11 @@ public class StayService {
 
     @Transactional(readOnly = true)
     public StayListResponse getStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
-        Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
+        if(checkIn.isBefore(LocalDate.now()))
+            throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
+        if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))
+            throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
+        Pageable pageable = PageRequest.of(page, 2);    //페이지당 데이터 수 8개 고정
         Page<Stay> stays = stayRepository.findBySalePriceBetweenAndCity(minPrice, maxPrice, city, pageable);
         return StayListResponse.from(city, checkIn, checkOut, stays);
     }

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -1,0 +1,29 @@
+package efub.agoda_server.stay.service;
+
+import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.dto.response.StayListResponse;
+import efub.agoda_server.stay.repository.StayRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StayService {
+
+    private final StayRepository stayRepository;
+
+    @Transactional(readOnly = true)
+    public StayListResponse getStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
+        Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
+        Page<Stay> stays = stayRepository.findBySalePriceBetweenAndCity(minPrice, maxPrice, city, pageable);
+        return StayListResponse.from(city, checkIn, checkOut, stays);
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +26,8 @@ public class StayService {
             throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
         if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))
             throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
-        Pageable pageable = PageRequest.of(page, 2);    //페이지당 데이터 수 8개 고정
-        Page<Stay> stays = stayRepository.findBySalePriceBetweenAndCity(minPrice, maxPrice, city, pageable);
+        Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
+        Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(minPrice, maxPrice, city, pageable);
         return StayListResponse.from(city, checkIn, checkOut, stays);
     }
 }


### PR DESCRIPTION
## 구현 기능
- 숙소 리스트 조회 api 구현

## 구현 상태
- 도시, 최소금액, 최대금액에 따라서 숙소 리스트를 페이징을 적용하여 조회합니다.
- 체크인과 체크아웃 날짜를 받아 총 금액을 보여줍니다.
- 체크인이 오늘 날짜보다 빠른 경우, 체크인이 체크아웃보다 느린 경우 예외처리를 진행했습니다.
- 아고다에서도 로그인을 하지 않고도 숙소 리스트를 볼 수 있길래 저희 서비스도 가능하도록 SecurityConfig 설정 추가했습니다!
- city 값을 컬럼으로 따로 빼지 않고, 검색한 도시를 address 내에서 찾아서 검색하도록 변경했습니다.

### 추가 사항 (엔티티 변경)
- 숙소 리스트를 불러올 때에는 `리뷰 전체 평점`, 숙소 상세 조회시에는 `리뷰 전체 평점 + 3개의 평점들의 각각의 평균`들의 값이 필요한데, 2가지 방법 중에서 고민했습니다
1. 숙소 리스트 혹은 상세 조회 할 때마다 리뷰를 매번 불러와서 평균 값 구하기
▶️ 조회할 때마다 평균들을 구해야함.
2. 숙소 엔티티에 아예 리뷰 전체 평점, 3개 각각의 평점 값들을 애초에 저장을 해두고, 그냥 꺼내서 쓰기.
▶️리뷰가 저장될 때 stay의 컬럼 변경해야함.

리스트 조회는 무엇보다 속도가 생명이라고 생각하는데, 나중에 리뷰의 개수가 많아지게 되면 리스트를 조회할 때 마다 모든 컬럼들의 값을 더해서 평균값들을 구해야 한다는 점에서 부담이 커질 것 같다고 판단하여 2번으로 진행하기로 했습니다!
그래서 stay entity에 `rating`, `addrRating`, `saniRating`, `servRating`, `reviewCnt` 컬럼을 추가하였습니다.

## Resolve
- #8
