### PR TITLE
[FEAT] 숙소 상세 조회 api

### DIFF
--- a/src/main/java/efub/agoda_server/global/exception/ErrorCode.java
+++ b/src/main/java/efub/agoda_server/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
 
     //stay 관련 에러
     PAST_CHECKIN_DATE(400, "체크인 날짜는 오늘 이후여야 합니다."),
-    INVALID_CHECKOUT_DATE(400, "체크아웃 날짜는 체크인 날짜보다 이후여야 합니다.");
+    INVALID_CHECKOUT_DATE(400, "체크아웃 날짜는 체크인 날짜보다 이후여야 합니다."),
+    STAY_NOT_FOUND(404, "숙박이 존재하지 않습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/efub/agoda_server/stay/controller/StayController.java
+++ b/src/main/java/efub/agoda_server/stay/controller/StayController.java
@@ -1,6 +1,7 @@
 package efub.agoda_server.stay.controller;
 
 import efub.agoda_server.stay.dto.response.StayListResponse;
+import efub.agoda_server.stay.dto.response.StayResponse;
 import efub.agoda_server.stay.service.StayService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -23,5 +24,10 @@ public class StayController {
                                                      @RequestParam("checkOut") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkOut,
                                                      @RequestParam(value = "page", defaultValue = "0") int page){
         return ResponseEntity.ok(stayService.getAllStays(city, minPrice, maxPrice, checkIn, checkOut, page));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StayResponse> getStay(@PathVariable("id") Long id){
+        return ResponseEntity.ok(stayService.getStay(id));
     }
 }

--- a/src/main/java/efub/agoda_server/stay/domain/Room.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Room.java
@@ -16,7 +16,16 @@ public class Room {
     private Long roomId;
 
     @Column(nullable = false)
-    private String name; // 슈페리어 트윈으로 고정
+    private String name;
+
+    @Column(nullable = false)
+    private String bed;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "sale_price", nullable = false)
+    private int salePrice;
 
     @Column(name = "room_image", nullable = false)
     private String roomImage;

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
@@ -1,19 +1,13 @@
 package efub.agoda_server.stay.dto.response;
 
-import efub.agoda_server.stay.domain.Stay;
 import efub.agoda_server.stay.dto.summary.StaySummary;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.cglib.core.Local;
-import org.springframework.data.domain.Page;
 
-import java.time.Duration;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -24,19 +18,12 @@ public class StayListResponse {
     private LocalDate checkOut;
     private List<StaySummary> stays;
 
-    public static StayListResponse from(String city, LocalDate checkIn, LocalDate checkOut, Page<Stay> stays) {
-        //총 숙박일
-        int totalDays = (int) ChronoUnit.DAYS.between(checkIn, checkOut);
-
-        List<StaySummary> staySummarys = stays.getContent().stream()
-                .map(stay -> StaySummary.from(stay, totalDays))
-                .collect(Collectors.toList());
-
+    public static StayListResponse from(String city, LocalDate checkIn, LocalDate checkOut, List<StaySummary> staySummaries) {
         return StayListResponse.builder()
                 .search(city)
                 .checkIn(checkIn)
                 .checkOut(checkOut)
-                .stays(staySummarys)
+                .stays(staySummaries)
                 .build();
     }
 }

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
@@ -2,6 +2,7 @@ package efub.agoda_server.stay.dto.response;
 
 import efub.agoda_server.stay.domain.Room;
 import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.domain.StayImage;
 import efub.agoda_server.stay.dto.summary.RoomSummary;
 import efub.agoda_server.stay.dto.summary.StayReviewSummary;
 import lombok.AccessLevel;
@@ -26,9 +27,13 @@ public class StayResponse {
     private List<RoomSummary> rooms;
     private StayReviewSummary review;
 
-    public static StayResponse from(Stay stay, List<Room> rooms) {
+    public static StayResponse from(Stay stay, List<StayImage> stayImages, List<Room> rooms) {
         List<RoomSummary> roomSummaries = rooms.stream()
                 .map(RoomSummary::of)
+                .collect(Collectors.toList());
+
+        List<String> stayImgList = stayImages.stream()
+                .map(stayImage -> stayImage.getStImage())
                 .collect(Collectors.toList());
 
         StayReviewSummary stayReviewSummary = StayReviewSummary.from(stay);
@@ -40,7 +45,7 @@ public class StayResponse {
                 .address(stay.getAddress())
                 .salePrice(stay.getSalePrice())
                 .tags(stay.getTags())
-                .stayImgUrls(List.of())
+                .stayImgUrls(stayImgList)
                 .rooms(roomSummaries)
                 .review(stayReviewSummary)
                 .build();

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
@@ -1,0 +1,51 @@
+package efub.agoda_server.stay.dto.response;
+
+import efub.agoda_server.stay.domain.Room;
+import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.dto.summary.RoomSummary;
+import efub.agoda_server.stay.dto.summary.StayReviewSummary;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StayResponse {
+    private Long id;
+    private String name;
+    private String detail;
+    private String address;
+    private int salePrice;
+    private List<String> tags;
+    private List<String> stayImgUrls;
+    private String roomImgUrls;
+    private List<RoomSummary> rooms;
+    private StayReviewSummary review;
+
+    //TODO: 이미지 경로 설정
+    public static StayResponse from(Stay stay, List<Room> rooms) {
+        List<RoomSummary> roomSummaries = rooms.stream()
+                .map(RoomSummary::of)
+                .collect(Collectors.toList());
+
+        StayReviewSummary stayReviewSummary = StayReviewSummary.from(stay);
+
+        return StayResponse.builder()
+                .id(stay.getStId())
+                .name(stay.getName())
+                .detail(stay.getDetail())
+                .address(stay.getAddress())
+                .salePrice(stay.getSalePrice())
+                .tags(stay.getTags())
+                .stayImgUrls(List.of())
+                .roomImgUrls("")
+                .rooms(roomSummaries)
+                .review(stayReviewSummary)
+                .build();
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayResponse.java
@@ -23,11 +23,9 @@ public class StayResponse {
     private int salePrice;
     private List<String> tags;
     private List<String> stayImgUrls;
-    private String roomImgUrls;
     private List<RoomSummary> rooms;
     private StayReviewSummary review;
 
-    //TODO: 이미지 경로 설정
     public static StayResponse from(Stay stay, List<Room> rooms) {
         List<RoomSummary> roomSummaries = rooms.stream()
                 .map(RoomSummary::of)
@@ -43,7 +41,6 @@ public class StayResponse {
                 .salePrice(stay.getSalePrice())
                 .tags(stay.getTags())
                 .stayImgUrls(List.of())
-                .roomImgUrls("")
                 .rooms(roomSummaries)
                 .review(stayReviewSummary)
                 .build();

--- a/src/main/java/efub/agoda_server/stay/dto/summary/RoomSummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/RoomSummary.java
@@ -14,6 +14,7 @@ public class RoomSummary {
     private String bed;
     private int roomPrice;
     private int roomSalePrice;
+    private String roomImgUrl;
 
     public static RoomSummary of(Room room){
         return RoomSummary.builder()
@@ -21,6 +22,7 @@ public class RoomSummary {
                 .bed(room.getBed())
                 .roomPrice(room.getPrice())
                 .roomSalePrice(room.getSalePrice())
+                .roomImgUrl(room.getRoomImage())
                 .build();
     }
 }

--- a/src/main/java/efub/agoda_server/stay/dto/summary/RoomSummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/RoomSummary.java
@@ -1,0 +1,26 @@
+package efub.agoda_server.stay.dto.summary;
+
+import efub.agoda_server.stay.domain.Room;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomSummary {
+    private String name;
+    private String bed;
+    private int roomPrice;
+    private int roomSalePrice;
+
+    public static RoomSummary of(Room room){
+        return RoomSummary.builder()
+                .name(room.getName())
+                .bed(room.getBed())
+                .roomPrice(room.getPrice())
+                .roomSalePrice(room.getSalePrice())
+                .build();
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/dto/summary/StayReviewSummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/StayReviewSummary.java
@@ -1,0 +1,28 @@
+package efub.agoda_server.stay.dto.summary;
+
+import efub.agoda_server.stay.domain.Stay;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StayReviewSummary {
+    private double rating;
+    private int reviewCnt;
+    private double addrRating;
+    private double saniRating;
+    private double servRating;
+
+    public static StayReviewSummary from(Stay stay) {
+        return StayReviewSummary.builder()
+                .rating(stay.getRating())
+                .reviewCnt(stay.getReviewCnt())
+                .addrRating(stay.getAddrRating())
+                .saniRating(stay.getSaniRating())
+                .servRating(stay.getServRating())
+                .build();
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
@@ -21,10 +21,9 @@ public class StaySummary {
     private int salePrice;
     private int totalPrice;
     private List<String> tags;
-    private List<String> stayImgUrls;
+    private String mainImageUrl;
 
-    //TODO: 이미지 경로 변경
-    public static StaySummary from(Stay stay, int totalDays){
+    public static StaySummary from(Stay stay, int totalDays, String imgUrl){
         return StaySummary.builder()
                 .id(stay.getStId())
                 .name(stay.getName())
@@ -35,7 +34,7 @@ public class StaySummary {
                 .salePrice(stay.getSalePrice())
                 .totalPrice(stay.getSalePrice() * totalDays)
                 .tags(stay.getTags())
-                .stayImgUrls(List.of())
+                .mainImageUrl(imgUrl)
                 .build();
     }
 }

--- a/src/main/java/efub/agoda_server/stay/repository/RoomRepository.java
+++ b/src/main/java/efub/agoda_server/stay/repository/RoomRepository.java
@@ -1,0 +1,11 @@
+package efub.agoda_server.stay.repository;
+
+import efub.agoda_server.stay.domain.Room;
+import efub.agoda_server.stay.domain.Stay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+    List<Room> findByStay(Stay stay);
+}

--- a/src/main/java/efub/agoda_server/stay/repository/StayImageRepository.java
+++ b/src/main/java/efub/agoda_server/stay/repository/StayImageRepository.java
@@ -1,0 +1,13 @@
+package efub.agoda_server.stay.repository;
+
+import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.domain.StayImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StayImageRepository extends JpaRepository<StayImage, Long> {
+    StayImage findFirstByStay(Stay stay);
+    List<StayImage> findByStay(Stay stay);
+}

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -2,8 +2,11 @@ package efub.agoda_server.stay.service;
 
 import efub.agoda_server.global.exception.CustomException;
 import efub.agoda_server.global.exception.ErrorCode;
+import efub.agoda_server.stay.domain.Room;
 import efub.agoda_server.stay.domain.Stay;
 import efub.agoda_server.stay.dto.response.StayListResponse;
+import efub.agoda_server.stay.dto.response.StayResponse;
+import efub.agoda_server.stay.repository.RoomRepository;
 import efub.agoda_server.stay.repository.StayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,21 +16,36 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StayService {
 
     private final StayRepository stayRepository;
+    private final RoomRepository roomRepository;
 
-    @Transactional(readOnly = true)
     public StayListResponse getAllStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
         if(checkIn.isBefore(LocalDate.now()))
             throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
         if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))
             throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
+
         Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
         Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(minPrice, maxPrice, city, pageable);
+
         return StayListResponse.from(city, checkIn, checkOut, stays);
+    }
+
+    public StayResponse getStay(Long id) {
+        Stay stay = findByStayId(id);
+        List<Room> rooms = roomRepository.findByStay(stay);
+        return StayResponse.from(stay, rooms);
+    }
+
+    public Stay findByStayId(Long id){
+        return stayRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.STAY_NOT_FOUND));
     }
 }

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -1,12 +1,15 @@
 package efub.agoda_server.stay.service;
 
-import efub.agoda_server.global.exception.CustomException;
+import  efub.agoda_server.global.exception.CustomException;
 import efub.agoda_server.global.exception.ErrorCode;
 import efub.agoda_server.stay.domain.Room;
 import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.domain.StayImage;
 import efub.agoda_server.stay.dto.response.StayListResponse;
 import efub.agoda_server.stay.dto.response.StayResponse;
+import efub.agoda_server.stay.dto.summary.StaySummary;
 import efub.agoda_server.stay.repository.RoomRepository;
+import efub.agoda_server.stay.repository.StayImageRepository;
 import efub.agoda_server.stay.repository.StayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,36 +19,54 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StayService {
 
     private final StayRepository stayRepository;
     private final RoomRepository roomRepository;
+    private final StayImageRepository stayImageRepository;
 
+    @Transactional(readOnly = true)
     public StayListResponse getAllStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
-        if(checkIn.isBefore(LocalDate.now()))
-            throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
-        if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))
-            throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
+        validateCheckInOutDate(checkIn, checkOut);
 
         Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
         Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(minPrice, maxPrice, city, pageable);
 
-        return StayListResponse.from(city, checkIn, checkOut, stays);
+        int totalDays = (int) ChronoUnit.DAYS.between(checkIn, checkOut);   //총 숙박일
+        //TODO: 이미지 불러올 때 n+1 방식 생길 것 같아 추후 리팩토링 필요
+        List<StaySummary> staySummaries = stays.getContent().stream()
+                .map(stay -> {
+                    StayImage img = stayImageRepository.findFirstByStay(stay);  //대표 이미지 추가
+                    return StaySummary.from(stay, totalDays, img != null ? img.getStImage() : null);
+                })
+                .collect(Collectors.toList());
+
+        return StayListResponse.from(city, checkIn, checkOut, staySummaries);
     }
 
+    @Transactional(readOnly = true)
     public StayResponse getStay(Long id) {
         Stay stay = findByStayId(id);
+        List<StayImage> stayImages = stayImageRepository.findByStay(stay);
         List<Room> rooms = roomRepository.findByStay(stay);
-        return StayResponse.from(stay, rooms);
+        return StayResponse.from(stay, stayImages, rooms);
     }
 
     public Stay findByStayId(Long id){
         return stayRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.STAY_NOT_FOUND));
+    }
+
+    public void validateCheckInOutDate(LocalDate checkIn, LocalDate checkOut){
+        if(checkIn.isBefore(LocalDate.now()))
+            throw new CustomException(ErrorCode.PAST_CHECKIN_DATE);
+        if(checkIn.isAfter(checkOut) || checkIn.isEqual(checkOut))
+            throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
     }
 }


### PR DESCRIPTION
## 구현 기능
- 숙소 상세 조회 api 구현

## 구현 상태
- 기존의 엔티티에서 침대 정보(bed), 가격(price), 할인 가격(sale price) 컬럼을 추가했습니다.
- api의 review 값들 (전체 평균, 리뷰 개수, 3개 리뷰들의 평균) 값들은 하나의 Object로 묶어서 반환했습니다.
- 이미지 관련 로직을 처리했습니다. 
원래는 1. 숙소 대표이미지를 stay 엔티티에 대표 이미지만 컬럼 하나를 추가하거나, 2. stayImage 엔티티에 대표사진 여부 컬럼을 하나 더 추가해서 숙소 대표사진인지에 관한 값을 추가로 넣어야 하지만, 
우선은 `stayImageRepository.findFirstByStay(stay);` 로 임의로 하나만 서치되게끔 했습니다.
### 추가사항
현재 구현해놓은 이미지를 불러오는 로직이 stayList에서 stayId마다 하나하나 stayImageRepository에서 불러와서 이미지를 dto에 넣고 있는 방식이라  **N+1 문제**가 발생할 것 같습니다!..
프로젝트 볼륨이 크지 않기도 하고, 페이징 때문에 한 번에 8개의 stay들만 조회해서 아직은 괜찮을 것 같지만, 추후 리팩토링 진행하겠습니다! 😄

## Resolve
- #8 
