### PR TITLE
[FEAT] 리뷰 등록 시 stay의 평점 관련 값 업데이트 기능 추가

### DIFF
--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -56,4 +56,12 @@ public class Stay {
     @Column(nullable = false, name = "review_cnt")
     @ColumnDefault("0")
     private int reviewCnt;
+
+    public void updateReview(double newAddrRating, double newSaniRating, double newServRating, double newRating) {
+        this.rating = newRating;
+        this.addrRating = newAddrRating;
+        this.saniRating = newSaniRating;
+        this.servRating = newServRating;
+        this.reviewCnt ++;
+    }
 }


### PR DESCRIPTION
## 구현 기능
- 리뷰 등록 시 해당 숙소의 평점 및 리뷰 개수를 자동으로 업데이트하는 로직 추가
  
## 구현 상태
-  stay 엔티티에 reviewCnt와 전체 평균, 3개 평점 각각의 평균값들을 저장하는 값이 있는데, 리뷰 등록 시 이 값을 업데이트하기 위한 함수를 추가해놓았습니다.
- 리뷰 등록 로직을 설계하실 때, StayService에 대한 의존성을 추가하시고 `stayService.updateReviewRating(review);` 한 줄만 호출해주시면 Stay의 평점 관련 컬럼들(rating, addrRating 등)도 자동으로 업데이트되니까 이 부분만 코드 추가 부탁드립니다! 😊@sohyu-na 

## Resolve
- close #8 
