### PR TITLE
[FIX] 리뷰 이미지 관련 에러 해결

### DIFF
--- a/src/main/java/efub/agoda_server/global/S3Image/S3Service.java
+++ b/src/main/java/efub/agoda_server/global/S3Image/S3Service.java
@@ -69,7 +69,7 @@ public class S3Service {
 
     //이미지 여러개 제거
     public void deleteFiles(List<String> fileUrls){
-        if (fileUrls == null || fileUrls.isEmpty()) {
+        if (fileUrls == null) {
             throw new CustomException(ErrorCode.NO_FILE_PROVIDED);
         }
 

--- a/src/main/java/efub/agoda_server/review/controller/ReviewController.java
+++ b/src/main/java/efub/agoda_server/review/controller/ReviewController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -27,9 +28,9 @@ public class ReviewController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> createReview(@AuthenticationPrincipal User user,
                                              @RequestPart("request") @Valid ReviewCreateRequest request,
-                                             @RequestPart("images") List<MultipartFile> images){
+                                             @RequestPart(value = "images", required = false) List<MultipartFile> images){
         System.out.println(request.getResId());
-        Long revId = reviewService.createReview(user, request, images);
+        Long revId = reviewService.createReview(user, request, images == null || images.isEmpty() ? Collections.emptyList() : images);
         return ResponseEntity.created(URI.create("/rev/" + revId)).build();
     }
     //리뷰 조회
@@ -40,13 +41,12 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
     //리뷰 수정
-    @PatchMapping("/{revId}")
+    @PatchMapping(value = "/{revId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ReviewResponse> updateReview(@AuthenticationPrincipal User user,
                                                        @PathVariable Long revId,
-                                                       @RequestBody ReviewUpdateRequest request,
-                                                       @RequestPart("images") List<MultipartFile> images){
-        ReviewResponse response = reviewService.updateReview(user, revId, request, images);
+                                                       @RequestPart ReviewUpdateRequest request,
+                                                       @RequestPart(value = "images", required = false) List<MultipartFile> images){
+        ReviewResponse response = reviewService.updateReview(user, revId, request, images == null || images.isEmpty() ? Collections.emptyList() : images);
         return ResponseEntity.ok(response);
     }
-
 }

--- a/src/main/java/efub/agoda_server/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/efub/agoda_server/review/dto/request/ReviewUpdateRequest.java
@@ -17,6 +17,4 @@ public class ReviewUpdateRequest {
     private Integer servRating;
     @JsonProperty("review_txt")
     private String reviewText;
-    @JsonProperty("rev_img_urls")
-    private List<String> revImgUrls;
 }

--- a/src/main/java/efub/agoda_server/review/repository/ReviewImgRepository.java
+++ b/src/main/java/efub/agoda_server/review/repository/ReviewImgRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface ReviewImgRepository extends JpaRepository<ReviewImg, Long> {
      List<ReviewImg> findAllByReview(Review review);
-     Void deleteAllByReview(Review review);
+     int deleteAllByReview(Review review);
 }


### PR DESCRIPTION
## 구현 기능
- 리뷰 이미지 관련 에러 해결

## 구현 상태
- 이미지가 하나도 들어오지 않을 경우 기존에는 에러처리를 했지만, 이미지가 없을 수도 있어 에러처리를 제거했습니다.
- `deleteAllByReview(Review review);` 함수의 반환값이 int가 아니라 void 형여서 에러가 나길래 수정했습니다!

## Resolve
- #26 
