### PR TITLE
[FIX] kakao 로그인 응답 전달방식 변경

### DIFF
--- a/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
+++ b/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
@@ -10,10 +10,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
@@ -28,10 +34,25 @@ public class SecurityConfig {
     private final CustomFailHandler failHandler;
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:5173", "https://efub-agoda.o-r.kr"));
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setMaxAge(3600L); // 1시간 캐시
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
     @Order(1)
     public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
                 .securityMatcher("/api/**")
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
                 .authorizeHttpRequests(auth -> auth
@@ -48,6 +69,7 @@ public class SecurityConfig {
     @Order(2)
     public SecurityFilterChain oauth2FilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/login/**", "/oauth2/**", "/stays/**").permitAll()
@@ -65,5 +87,4 @@ public class SecurityConfig {
 
         return http.build();
     }
-
 }


### PR DESCRIPTION
## 구현 기능
- kakao 로그인 응답 전달방식 변경

## 구현 상태
- CustomSuccessHandler 수정
  - 기존 JSON 직접 반환 → 팝업에서 `postMessage` 스크립트로 응답 전달하도록 변경  
- redirect-uri 설정 통일
  - 카카오 OAuth2 콜백 URL을 `https://efub-agoda.o-r.kr/login/oauth2/code/kakao`으로 일치  
- 프론트 팝업 메시지 수신 구조 준비
  - `window.open`으로 팝업 열기  
  - 부모 창에서 `window.addEventListener('message', …)`로 토큰/유저 정보 수신

## Resolve
- #2 
