### PR TITLE
[FIX] 리뷰 수정 시 stay의 별점 컬럼값도 수정하는 로직 추가

### DIFF
--- a/src/main/java/efub/agoda_server/review/controller/ReviewController.java
+++ b/src/main/java/efub/agoda_server/review/controller/ReviewController.java
@@ -44,7 +44,7 @@ public class ReviewController {
     @PatchMapping(value = "/{revId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ReviewResponse> updateReview(@AuthenticationPrincipal User user,
                                                        @PathVariable Long revId,
-                                                       @RequestPart ReviewUpdateRequest request,
+                                                       @RequestPart("request") @Valid ReviewUpdateRequest request,
                                                        @RequestPart(value = "images", required = false) List<MultipartFile> images){
         ReviewResponse response = reviewService.updateReview(user, revId, request, images == null || images.isEmpty() ? Collections.emptyList() : images);
         return ResponseEntity.ok(response);

--- a/src/main/java/efub/agoda_server/review/domain/Review.java
+++ b/src/main/java/efub/agoda_server/review/domain/Review.java
@@ -56,4 +56,21 @@ public class Review {
         this.text = reviewText;
         this.updatedAt = updatedAt;
     }
+
+    //review 수정 시 rating 복사
+    public static Review copyRatingsFrom(Review review) {
+        return new Review(
+                review.getAddrRating(),
+                review.getSaniRating(),
+                review.getServRating(),
+                review.getReservation() // stay 정보용
+        );
+    }
+
+    public Review(int addrRating, int saniRating, int servRating, Reservation reservation) {
+        this.addrRating = addrRating;
+        this.saniRating = saniRating;
+        this.servRating = servRating;
+        this.reservation = reservation;
+    }
 }

--- a/src/main/java/efub/agoda_server/review/service/ReviewService.java
+++ b/src/main/java/efub/agoda_server/review/service/ReviewService.java
@@ -55,7 +55,7 @@ public class ReviewService {
                         .build())
                 .toList();
         reviewImgRepository.saveAll(reviewImgs);
-        stayService.updateReviewRating(review);
+        stayService.updateRatingForNewReview(review);
         return review.getRevId();
     }
 
@@ -78,6 +78,7 @@ public class ReviewService {
         if (!review.getUser().getUserId().equals(user.getUserId())) {
             throw new CustomException(ErrorCode.REVIEW_ACCESS_DENIED);
         }
+        Review oldReview = Review.copyRatingsFrom(review);
         review.updateAll(
                 request.getAddrRating(),
                 request.getSaniRating(),
@@ -86,6 +87,7 @@ public class ReviewService {
                 LocalDateTime.now()
         );
 
+        stayService.updateRatingForEditReview(oldReview, review);
         updateReviewImages(review, images);
 
         return buildReviewResponse(review);

--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -60,6 +60,9 @@ public class Stay {
     @ColumnDefault("0")
     private int reviewCnt;
 
+    @Column(name = "main_image")
+    private String mainImageUrl;
+
     public void updateReview(double newAddrRating, double newSaniRating, double newServRating, double newRating) {
         this.rating = newRating;
         this.addrRating = newAddrRating;

--- a/src/main/java/efub/agoda_server/stay/domain/Stay.java
+++ b/src/main/java/efub/agoda_server/stay/domain/Stay.java
@@ -71,4 +71,10 @@ public class Stay {
         this.reviewCnt ++;
     }
 
+    public void updateReviewAfterEdit(double newAddrRating, double newSaniRating, double newServRating, double newRating) {
+        this.rating = newRating;
+        this.addrRating = newAddrRating;
+        this.saniRating = newSaniRating;
+        this.servRating = newServRating;
+    }
 }

--- a/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
+++ b/src/main/java/efub/agoda_server/stay/dto/summary/StaySummary.java
@@ -23,7 +23,7 @@ public class StaySummary {
     private List<String> tags;
     private String mainImageUrl;
 
-    public static StaySummary from(Stay stay, int totalDays, String imgUrl){
+    public static StaySummary from(Stay stay, int totalDays){
         return StaySummary.builder()
                 .id(stay.getStId())
                 .name(stay.getName())
@@ -34,7 +34,7 @@ public class StaySummary {
                 .salePrice(stay.getSalePrice())
                 .totalPrice(stay.getSalePrice() * totalDays)
                 .tags(stay.getTags())
-                .mainImageUrl(imgUrl)
+                .mainImageUrl(stay.getMainImageUrl())
                 .build();
     }
 }

--- a/src/main/java/efub/agoda_server/stay/repository/StayImageRepository.java
+++ b/src/main/java/efub/agoda_server/stay/repository/StayImageRepository.java
@@ -7,6 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface StayImageRepository extends JpaRepository<StayImage, Long> {
-    StayImage findFirstByStay(Stay stay);
     List<StayImage> findAllByStay(Stay stay);
 }

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -40,11 +40,9 @@ public class StayService {
         Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(minPrice, maxPrice, city, pageable);
 
         int totalDays = (int) ChronoUnit.DAYS.between(checkIn, checkOut);   //총 숙박일
-        //TODO: 이미지 불러올 때 n+1 방식 생길 것 같아 추후 리팩토링 필요
         List<StaySummary> staySummaries = stays.getContent().stream()
                 .map(stay -> {
-                    StayImage img = stayImageRepository.findFirstByStay(stay);  //대표 이미지 추가
-                    return StaySummary.from(stay, totalDays, img != null ? img.getStImage() : null);
+                    return StaySummary.from(stay, totalDays);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -58,15 +58,28 @@ public class StayService {
     }
 
     @Transactional
-    public void updateReviewRating(Review review){
+    public void updateRatingForNewReview(Review review){
         Stay searchStay = findByStayId(review.getReservation().getStay().getStId());
-
         int prevReviewCnt = searchStay.getReviewCnt();
+
         double newAddrRating = calculateReviewAvg(searchStay.getAddrRating(), review.getAddrRating(), prevReviewCnt);
         double newSaniRating = calculateReviewAvg(searchStay.getSaniRating(), review.getSaniRating(), prevReviewCnt);
         double newServRating = calculateReviewAvg(searchStay.getServRating(), review.getServRating(), prevReviewCnt);
         double newRating = (newAddrRating + newSaniRating + newServRating) / 3;
         searchStay.updateReview(newAddrRating, newSaniRating, newServRating, newRating);
+    }
+
+    @Transactional
+    public void updateRatingForEditReview(Review oldReview, Review updatedReview){
+        Stay searchStay = findByStayId(updatedReview.getReservation().getStay().getStId());
+        int reviewCnt = searchStay.getReviewCnt();
+
+        double newAddrRating = recalculateAvgAfterEdit(searchStay.getAddrRating(), oldReview.getAddrRating(), updatedReview.getAddrRating(), reviewCnt);
+        double newSaniRating = recalculateAvgAfterEdit(searchStay.getSaniRating(), oldReview.getSaniRating(), updatedReview.getSaniRating(), reviewCnt);
+        double newServRating = recalculateAvgAfterEdit(searchStay.getServRating(), oldReview.getServRating(), updatedReview.getServRating(), reviewCnt);
+        double newRating = (newAddrRating + newSaniRating + newServRating) / 3;
+
+        searchStay.updateReviewAfterEdit(newAddrRating, newSaniRating, newServRating, newRating);
     }
 
     public Stay findByStayId(Long id){
@@ -81,7 +94,13 @@ public class StayService {
             throw new CustomException(ErrorCode.INVALID_CHECKOUT_DATE);
     }
 
-    public double calculateReviewAvg(double prevReviewScore, double newReview, int prevReviewCnt){
-        return (prevReviewScore * prevReviewCnt + newReview) / (prevReviewCnt + 1);
+    public double calculateReviewAvg(double prevAvg, double newValue, int prevCnt){
+        return (prevAvg * prevCnt + newValue) / (prevCnt + 1);
+    }
+
+    public double recalculateAvgAfterEdit(double oldAvg, double oldValue, double newValue, int count) {
+        if (count == 0)
+            return newValue; // 0으로 나누는 경우 방지
+        return (oldAvg * count - oldValue + newValue) / count;
     }
 }


### PR DESCRIPTION
## 구현 기능
- 리뷰 수정 시 stay의 별점 컬럼값도 수정하는 로직 추가

## 구현 상태
- stay의 대표 이미지를 저장하는 컬럼을 stay에 추가했습니다. 이미지를 불러올 때 n+1 문제를 해결하기 위해서 로직 변경을 고민하다가... 그냥 stay에 대표이미지 컬럼을 추가하기로 했습니다
- 누락되었던 리뷰 수정 시 requestPart에 들어갔던 dto의 value 값을 명시해주지 않아 추가해주었습니다.
- 리뷰 수정 시에 stay의 별점 컬럼값도 수정하는 로직을 추가했습니다.

## Resolve
