### PR TITLE
[HOTFIX] stay api는 인증 없어도 접근 가능하도록 수정

### DIFF
--- a/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
+++ b/src/main/java/efub/agoda_server/global/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/login/**", "/oauth2/**").permitAll()
+                        .requestMatchers("/login/**", "/oauth2/**", "/stays/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## 구현 기능
- stay api는 인증 없어도 접근 가능하도록 수정

## 구현 상태
- `.requestMatchers("/login/**", "/oauth2/**", "/stays/**").permitAll()` 

## Resolve
