### PR TITLE
[REFACTOR] 숙소 리스트 조회 시 ModelAttribute와 dto 사용으로 변경

### DIFF
--- a/src/main/java/efub/agoda_server/stay/controller/StayController.java
+++ b/src/main/java/efub/agoda_server/stay/controller/StayController.java
@@ -1,14 +1,13 @@
 package efub.agoda_server.stay.controller;
 
+import efub.agoda_server.stay.dto.request.StaySearchRequest;
 import efub.agoda_server.stay.dto.response.StayListResponse;
 import efub.agoda_server.stay.dto.response.StayResponse;
 import efub.agoda_server.stay.service.StayService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/stays")
@@ -17,13 +16,8 @@ public class StayController {
     private final StayService stayService;
 
     @GetMapping
-    public ResponseEntity<StayListResponse> getAllStays(@RequestParam("city") String city,
-                                                     @RequestParam(value = "minPrice", defaultValue = "0") int minPrice,
-                                                     @RequestParam(value = "maxPrice", defaultValue = "2147483647") int maxPrice,
-                                                     @RequestParam("checkIn") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkIn,
-                                                     @RequestParam("checkOut") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate checkOut,
-                                                     @RequestParam(value = "page", defaultValue = "0") int page){
-        return ResponseEntity.ok(stayService.getAllStays(city, minPrice, maxPrice, checkIn, checkOut, page));
+    public ResponseEntity<StayListResponse> getAllStays(@Valid @ModelAttribute StaySearchRequest request){
+        return ResponseEntity.ok(stayService.getAllStays(request));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/efub/agoda_server/stay/dto/request/StaySearchRequest.java
+++ b/src/main/java/efub/agoda_server/stay/dto/request/StaySearchRequest.java
@@ -1,0 +1,43 @@
+package efub.agoda_server.stay.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class StaySearchRequest {
+
+    @NotBlank(message = "도시명은 필수입니다.")
+    private String city;
+
+    @Min(value = 0, message = "최소 가격은 0 이상이어야 합니다.")
+    private Integer minPrice;
+
+    @Max(value = Integer.MAX_VALUE)
+    private Integer maxPrice;
+
+    @NotNull(message = "체크인 날짜는 필수입니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate checkIn;
+
+    @NotNull(message = "체크아웃 날짜는 필수입니다.")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate checkOut;
+
+    @Min(value = 0, message = "페이지는 0 이상이어야 합니다.")
+    private Integer page;
+
+    public StaySearchRequest(String city, Integer minPrice, Integer maxPrice, LocalDate checkIn, LocalDate checkOut, Integer page) {
+        this.city = city;
+        this.minPrice = (minPrice == null) ? 0 : minPrice;
+        this.maxPrice = (maxPrice == null) ? Integer.MAX_VALUE : maxPrice;
+        this.checkIn = checkIn;
+        this.checkOut = checkOut;
+        this.page = (page == null) ? 0 : page;
+    }
+}

--- a/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
+++ b/src/main/java/efub/agoda_server/stay/dto/response/StayListResponse.java
@@ -1,13 +1,17 @@
 package efub.agoda_server.stay.dto.response;
 
+import efub.agoda_server.stay.domain.Stay;
+import efub.agoda_server.stay.dto.request.StaySearchRequest;
 import efub.agoda_server.stay.dto.summary.StaySummary;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -18,11 +22,15 @@ public class StayListResponse {
     private LocalDate checkOut;
     private List<StaySummary> stays;
 
-    public static StayListResponse from(String city, LocalDate checkIn, LocalDate checkOut, List<StaySummary> staySummaries) {
+    public static StayListResponse from(StaySearchRequest request, Page<Stay> stays, int totalDays) {
+        List<StaySummary> staySummaries = stays.getContent().stream()
+                .map(stay -> StaySummary.from(stay, totalDays))
+                .collect(Collectors.toList());
+
         return StayListResponse.builder()
-                .search(city)
-                .checkIn(checkIn)
-                .checkOut(checkOut)
+                .search(request.getCity())
+                .checkIn(request.getCheckIn())
+                .checkOut(request.getCheckOut())
                 .stays(staySummaries)
                 .build();
     }

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -40,14 +40,9 @@ public class StayService {
         Pageable pageable = PageRequest.of(request.getPage(), 8);    //페이지당 데이터 수 8개 고정
         Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(request.getMinPrice(), request.getMaxPrice(), request.getCity(), pageable);
 
-        int totalDays = (int) ChronoUnit.DAYS.between(request.getCheckIn(), request.getCheckOut());   //총 숙박일
-        List<StaySummary> staySummaries = stays.getContent().stream()
-                .map(stay -> {
-                    return StaySummary.from(stay, totalDays);
-                })
-                .collect(Collectors.toList());
+        int totalDays = (int) ChronoUnit.DAYS.between(request.getCheckIn(), request.getCheckOut()); //총 숙박일
 
-        return StayListResponse.from(request.getCity(), request.getCheckIn(), request.getCheckOut(), staySummaries);
+        return StayListResponse.from(request, stays, totalDays);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/efub/agoda_server/stay/service/StayService.java
+++ b/src/main/java/efub/agoda_server/stay/service/StayService.java
@@ -1,11 +1,12 @@
 package efub.agoda_server.stay.service;
 
-import  efub.agoda_server.global.exception.CustomException;
+import efub.agoda_server.global.exception.CustomException;
 import efub.agoda_server.global.exception.ErrorCode;
 import efub.agoda_server.review.domain.Review;
 import efub.agoda_server.stay.domain.Room;
 import efub.agoda_server.stay.domain.Stay;
 import efub.agoda_server.stay.domain.StayImage;
+import efub.agoda_server.stay.dto.request.StaySearchRequest;
 import efub.agoda_server.stay.dto.response.StayListResponse;
 import efub.agoda_server.stay.dto.response.StayResponse;
 import efub.agoda_server.stay.dto.summary.StaySummary;
@@ -33,20 +34,20 @@ public class StayService {
     private final StayImageRepository stayImageRepository;
 
     @Transactional(readOnly = true)
-    public StayListResponse getAllStays(String city, int minPrice, int maxPrice, LocalDate checkIn, LocalDate checkOut, int page) {
-        validateCheckInOutDate(checkIn, checkOut);
+    public StayListResponse getAllStays(StaySearchRequest request) {
+        validateCheckInOutDate(request.getCheckIn(), request.getCheckOut());
 
-        Pageable pageable = PageRequest.of(page, 8);    //페이지당 데이터 수 8개 고정
-        Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(minPrice, maxPrice, city, pageable);
+        Pageable pageable = PageRequest.of(request.getPage(), 8);    //페이지당 데이터 수 8개 고정
+        Page<Stay> stays = stayRepository.findBySalePriceBetweenAndAddressContaining(request.getMinPrice(), request.getMaxPrice(), request.getCity(), pageable);
 
-        int totalDays = (int) ChronoUnit.DAYS.between(checkIn, checkOut);   //총 숙박일
+        int totalDays = (int) ChronoUnit.DAYS.between(request.getCheckIn(), request.getCheckOut());   //총 숙박일
         List<StaySummary> staySummaries = stays.getContent().stream()
                 .map(stay -> {
                     return StaySummary.from(stay, totalDays);
                 })
                 .collect(Collectors.toList());
 
-        return StayListResponse.from(city, checkIn, checkOut, staySummaries);
+        return StayListResponse.from(request.getCity(), request.getCheckIn(), request.getCheckOut(), staySummaries);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 구현 기능
- 숙소 리스트 조회 시 RequestParam 대신 ModelAttribute와 dto 사용으로 변경

## 구현 상태
- checkIn, checkOut 기간 설정 없이 + 검색 지역 없이 서버로 넘겨졌을 경우 에러처리가 되지 않아서 서비스단에서 해결할까 하다가, 쿼리파라미터 값을 dto로 묶어 기존에 사용하던 검증 방법인 `@Valid`를 쓸 수 있도록 변경했습니다.
- https://jettieb.notion.site/GetMapping-208e3f1f94a980839a9fe1d92633e8a7?source=copy_link
- 관련 정리본입니다!..

## Resolve
- #8
